### PR TITLE
Adds index-dataset command, adapt frontend to use new indexing scheme and concise descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.egg-info
 .terraform
 log.txt
+venv/

--- a/ckangpt/backend/cli.py
+++ b/ckangpt/backend/cli.py
@@ -25,6 +25,25 @@ def describe_dataset(glob=False, **kwargs):
 
 
 @backend.command()
+@click.argument("DATASET_DOMAIN")
+@click.argument("DATASET_NAME")
+@click.option('--load-from-disk', is_flag=True)
+@click.option('--save-to-disk', is_flag=True)
+@click.option('--save-to-storage', is_flag=True)
+@click.option('--glob', is_flag=True, help="DATASET_ arguments will be treated as globs to match over all domains/datasets in storage")
+@click.option('--limit', type=int)
+@click.option('--force-update', is_flag=True)
+@click.option('--collection-name', type=str)
+def index_dataset(glob=False, **kwargs):
+    from . import index_dataset
+    if glob:
+        for desc in index_dataset.main_glob(**kwargs):
+            common.print_separator(desc, pprint=True)
+    else:
+        common.print_separator(index_dataset.main(**kwargs), pprint=True)
+
+
+@backend.command()
 @click.argument('DOMAIN')
 @click.option('--limit', type=int)
 @click.option('--save-to-disk', is_flag=True)

--- a/ckangpt/backend/index_dataset.py
+++ b/ckangpt/backend/index_dataset.py
@@ -1,0 +1,86 @@
+import fnmatch
+
+import openai
+
+from ckangpt import config, storage, vectordb
+from ckangpt.vectordb.base import BaseItem
+
+
+def main_glob(dataset_domain, dataset_name,
+              load_from_disk=False, save_to_disk=False, save_to_storage=False,
+              force_update=False, limit=None, collection_name=None):
+    print(f'Indexing datasets matching glob pattern {dataset_domain}/{dataset_name}')
+
+    vdb = vectordb.get_vector_db_instance()
+    collection_name = collection_name or vdb.get_default_collection_name()
+    collection = vdb.get_datasets_collection(override_collection_name=collection_name)
+
+    matching_domains = set()
+    for item in storage.list_(prefix='dataset_descriptions/'):
+        domain = item.split('/')[1]
+        if fnmatch.fnmatchcase(domain.lower(), dataset_domain.lower()):
+            matching_domains.add(domain)
+    i = 0
+    for domain in matching_domains:
+        for item in storage.list_(prefix=f'dataset_descriptions/{domain}/'):
+            name = item.split('/')[2]
+            if fnmatch.fnmatchcase(name.lower(), dataset_name.lower()):
+                yield main(domain, name, 
+                           load_from_disk=load_from_disk, save_to_disk=save_to_disk, save_to_storage=save_to_storage,
+                           force_update=force_update, collection=collection)
+                i += 1
+                if limit and i >= limit:
+                    return
+
+
+def main(dataset_domain, dataset_name,
+         load_from_disk=False, save_to_disk=False, save_to_storage=False,
+         force_update=False, limit=None, collection_name=None, collection=None):
+    assert not limit
+    itempathparts = 'dataset_embeddings', dataset_domain, dataset_name
+    item = None
+    if not force_update:
+        item, metadata = storage.load(*itempathparts, with_metadata=True, load_from_disk=load_from_disk)
+        if item and not storage.is_updated_item_meteadata(metadata):
+            if config.ENABLE_DEBUG:
+                print("dataset embedding already exists in storage and does not require update")
+    if not item:
+        dataset_description = storage.load('dataset_descriptions', dataset_domain, dataset_name, load_from_disk=load_from_disk)
+        if not dataset_description:
+            if config.ENABLE_DEBUG:
+                print("dataset description not found in storage, skipping")
+                return
+        summary = dataset_description.get('summary')
+        if not summary:
+            if config.ENABLE_DEBUG:
+                print("dataset summary not found in description, skipping")
+                return
+        embedding = openai.Embedding.create(input=summary, model='text-embedding-ada-002')
+        if not embedding and config.ENABLE_DEBUG:
+            print("failed to generate embedding, skipping")
+            return
+        embedding = embedding['data'][0]['embedding']
+    else:
+        embedding = item['embedding']
+
+    if not collection:
+        vdb = vectordb.get_vector_db_instance()
+        collection_name = collection_name or vdb.get_default_collection_name()
+        collection = vdb.get_datasets_collection(override_collection_name=collection_name)
+    path = '/'.join(itempathparts)
+    indexed_item = BaseItem(
+        id=path,
+        embeddings=[embedding],
+        metadata=dict(dataset_domain=dataset_domain, dataset_name=dataset_name),
+        document=['dataset_descriptions', dataset_domain, dataset_name]
+    )
+    collection.add([indexed_item])
+
+    item = dict(
+        embedding=embedding
+    )
+    if save_to_disk:
+        storage.save_to_disk(item, *itempathparts)
+    if save_to_storage:
+        storage.save(item, *itempathparts)
+    return True

--- a/ckangpt/frontend/cli.py
+++ b/ckangpt/frontend/cli.py
@@ -37,6 +37,7 @@ def get_documents_from_vector_db(query, **kwargs):
 @click.option('--from-db-query', type=str)
 @click.option('--from-document-ids', type=str)
 @click.option('--from-user-prompt', type=str)
+@click.option('--load-from-disk', is_flag=True)
 @click.option('--num-results', type=int, default=DEFAULT_NUM_RESULTS)
 @click.option('--max-tokens', type=int)
 def get_context_from_documents(**kwargs):
@@ -53,6 +54,7 @@ def get_context_from_documents(**kwargs):
 @click.option('--db-query', type=str)
 @click.option('--document-ids', type=str)
 @click.option('--num-results', type=int, default=DEFAULT_NUM_RESULTS)
+@click.option('--load-from-disk', is_flag=True)
 def get_answer_from_prompt_context(**kwargs):
     from . import get_answer_from_prompt_context
     kwargs['document_ids'] = kwargs['document_ids'].split(',') if kwargs['document_ids'] else None
@@ -65,6 +67,7 @@ def get_answer_from_prompt_context(**kwargs):
 @click.argument("USER_PROMPT")
 @click.option('--document-ids', type=str)
 @click.option('--num-results', type=int, default=DEFAULT_NUM_RESULTS)
+@click.option('--load-from-disk', is_flag=True)
 def find_datasets(**kwargs):
     from . import find_datasets
     usage, answer = find_datasets.main(**kwargs)

--- a/ckangpt/frontend/find_datasets.py
+++ b/ckangpt/frontend/find_datasets.py
@@ -1,12 +1,12 @@
 import json
 
 from . import get_answer_from_prompt_context
-from ckangpt import config, vectordb
+from ckangpt import config, vectordb, storage
 
 
-def main(user_prompt, document_ids=None, num_results=config.DEFAULT_NUM_RESULTS):
+def main(user_prompt, document_ids=None, num_results=config.DEFAULT_NUM_RESULTS, load_from_disk=False):
     vdb = vectordb.get_vector_db_instance()
-    usage, answer = get_answer_from_prompt_context.main(user_prompt, document_ids=document_ids, num_results=num_results)
+    usage, answer = get_answer_from_prompt_context.main(user_prompt, document_ids=document_ids, num_results=num_results, load_from_disk=load_from_disk)
     docs = {}
     for doc in answer['relevant_datasets']:
         docs[doc['id']] = doc
@@ -14,7 +14,7 @@ def main(user_prompt, document_ids=None, num_results=config.DEFAULT_NUM_RESULTS)
     item_ids = list(docs.keys())
     if len(item_ids) > 0:
         for id, document in collection.iterate_item_documents(item_ids=list(docs.keys())):
-            docs[id]['document'] = json.loads(document)
+            docs[id]['document'] = storage.load(*document, load_from_disk=load_from_disk, with_metadata=False)
         return usage, {
             **answer,
             'relevant_datasets': list(sorted(docs.values(), key=lambda d: d['relevancy'])),

--- a/ckangpt/frontend/get_answer_from_prompt_context.py
+++ b/ckangpt/frontend/get_answer_from_prompt_context.py
@@ -86,7 +86,7 @@ Query: {{user_prompt}}
 '''
 
 
-def main(user_prompt, db_query=None, document_ids=None, num_results=config.DEFAULT_NUM_RESULTS):
+def main(user_prompt, db_query=None, document_ids=None, num_results=config.DEFAULT_NUM_RESULTS, load_from_disk=False):
     llm = guidance.llms.OpenAI(config.model_name(), chat_mode=True, caching=config.ENABLE_CACHE)
     context_usage = {}
 
@@ -95,6 +95,7 @@ def main(user_prompt, db_query=None, document_ids=None, num_results=config.DEFAU
         get_context_kwargs = {
             'num_results': num_results,
             'max_tokens': model_max_tokens - num_prompt_tokens - gen_max_tokens,
+            'load_from_disk': load_from_disk,
         }
         if db_query:
             assert not document_ids

--- a/ckangpt/frontend/get_vector_db_query.py
+++ b/ckangpt/frontend/get_vector_db_query.py
@@ -143,10 +143,15 @@ def get_critic_example_json(example):
 
 
 def get_critic_user_query(user_prompt, vector_db_query_json_uncriticized):
-    return json.dumps({
-        'query': user_prompt,
-        **json.loads(vector_db_query_json_uncriticized),
-    })
+    try:
+        return json.dumps({
+            'query': user_prompt,
+            **json.loads(vector_db_query_json_uncriticized),
+        })
+    except json.decoder.JSONDecodeError:
+        return json.dumps({
+            'query': user_prompt,
+        })
 
 
 def main(user_prompt):


### PR DESCRIPTION
@OriHoch 

I added a new 'index-dataset' command which works in a similar fashion to the 'describe-dataset' one.
It writes the embedding to the vector db (tested with pinecone) and stores the dataset description path parts as the 'document'.
I've also modified the frontend code a little so that:
- When fetching from the frontend db it will fetch the descriptions from storage.
- Context now only uses the generated descriptions and not the datasets, so it's smaller and simpler to generate.